### PR TITLE
feature: Proper context cancellation and better output collection

### DIFF
--- a/internal/cli/run/common.go
+++ b/internal/cli/run/common.go
@@ -1,8 +1,9 @@
 package run
 
 type CommonRunnableOpts struct {
-	Watch  bool    `short:"w" help:"Watch the output live"`
-	LogDir *string `short:"l" help:"Optional directory to save logs to. Will be created if it does not exist." type:"path"`
-	JUnit  *string `short:"j" help:"Produce JUnit XML output at the given path." type:"path"`
-	Output *string `short:"o" long:"artifact-output-dir" help:"Optional directory to output artifacts to." type:"path"`
+	Watch        bool    `short:"w" help:"Watch the output live"`
+	LogDir       *string `short:"l" help:"Optional directory to save logs to. Will be created if it does not exist." type:"path"`
+	JUnit        *string `short:"j" help:"Produce JUnit XML output at the given path." type:"path"`
+	Output       *string `short:"o" long:"artifact-output-dir" help:"Optional directory to output artifacts to." type:"path"`
+	PauseCleanup bool    `short:"c" help:"Wait for an external signal (SIGINT|SIGTERM) before cleaning up and exiting. This is useful for local debugging where you may want to inspect the environment after the test finishes."`
 }

--- a/internal/cli/run/helper.go
+++ b/internal/cli/run/helper.go
@@ -22,6 +22,7 @@ func (cmd *HelperCmd) Run(suite core.SuiteContext) error {
 		helper,
 		cmd.HelperArgs,
 		cmd.Common.Watch,
+		cmd.Common.PauseCleanup,
 		cmd.Common.LogDir,
 		cmd.Common.JUnit,
 		cmd.Common.Output,

--- a/internal/cli/run/scenario.go
+++ b/internal/cli/run/scenario.go
@@ -22,6 +22,7 @@ func (cmd *ScenarioCmd) Run(suite core.SuiteContext) error {
 		scenario,
 		cmd.ScenarioArgs,
 		cmd.Common.Watch,
+		cmd.Common.PauseCleanup,
 		cmd.Common.LogDir,
 		cmd.Common.JUnit,
 		cmd.Common.Output,

--- a/internal/runner/cancellation_test.go
+++ b/internal/runner/cancellation_test.go
@@ -1,0 +1,186 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/microsoft/storm/internal/artifacts"
+	"github.com/microsoft/storm/internal/testmgr"
+	"github.com/microsoft/storm/pkg/storm/core"
+
+	"github.com/sirupsen/logrus"
+)
+
+// fakeSuite is a minimal core.SuiteContext for exercising executeTestCases.
+type fakeSuite struct {
+	log *logrus.Logger
+	ctx context.Context
+}
+
+func newFakeSuite(ctx context.Context) *fakeSuite {
+	logger := logrus.New()
+	logger.SetOutput(&bytes.Buffer{}) // keep logger noise out of test output
+	return &fakeSuite{log: logger, ctx: ctx}
+}
+
+func (s *fakeSuite) Name() string                  { return "storm-test" }
+func (s *fakeSuite) Logger() *logrus.Logger        { return s.log }
+func (s *fakeSuite) Scenarios() []core.Scenario    { return nil }
+func (s *fakeSuite) Scenario(string) core.Scenario { return nil }
+func (s *fakeSuite) Helpers() []core.Helper        { return nil }
+func (s *fakeSuite) Helper(string) core.Helper     { return nil }
+func (s *fakeSuite) AzureDevops() bool             { return false }
+func (s *fakeSuite) Context() context.Context      { return s.ctx }
+
+// fakeHelper is a configurable core.Helper (optionally core.SetupCleanup).
+type fakeHelper struct {
+	numCases   int
+	setupFn    func() error
+	cleanupFn  func() error
+	suiteClean func() // registered via tc.SuiteCleanup on the first case
+}
+
+func (h *fakeHelper) Name() string { return "hw" }
+func (h *fakeHelper) Args() any    { return nil }
+func (h *fakeHelper) RegisterTestCases(r core.TestRegistrar) error {
+	for i := 0; i < h.numCases; i++ {
+		name := fmt.Sprintf("case%d", i)
+		first := i == 0
+		r.RegisterTestCase(name, func(tc core.TestCase) error {
+			if first && h.suiteClean != nil {
+				tc.SuiteCleanup(h.suiteClean)
+			}
+			return nil
+		})
+	}
+	return nil
+}
+
+// Setup/Cleanup are only used when the test sets setupFn/cleanupFn.
+func (h *fakeHelper) Setup(core.SetupCleanupContext) error {
+	if h.setupFn != nil {
+		return h.setupFn()
+	}
+	return nil
+}
+
+func (h *fakeHelper) Cleanup(core.SetupCleanupContext) error {
+	if h.cleanupFn != nil {
+		return h.cleanupFn()
+	}
+	return nil
+}
+
+func newTestManager(t *testing.T, suite core.SuiteContext, helper *fakeHelper) (*testmgr.StormTestManager, *runnableInstance) {
+	t.Helper()
+	registrant := &runnableInstance{Argumented: helper, TestRegistrant: helper}
+	am, err := artifacts.NewArtifactManager(suite, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create artifact manager: %v", err)
+	}
+	tm, err := testmgr.NewStormTestManager(suite, registrant, am)
+	if err != nil {
+		t.Fatalf("failed to create test manager: %v", err)
+	}
+	return tm, registrant
+}
+
+// When the suite context is already cancelled, every test case must be marked
+// NotRun rather than executed.
+func TestExecuteTestCasesSuiteCancelledMarksNotRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before running
+
+	suite := newFakeSuite(ctx)
+	helper := &fakeHelper{numCases: 3}
+	tm, registrant := newTestManager(t, suite, helper)
+
+	if err := executeTestCases(suite, registrant, tm, false, false); err != nil {
+		t.Fatalf("executeTestCases returned error: %v", err)
+	}
+
+	for _, tc := range tm.TestCases() {
+		if !tc.Status().NotRun() {
+			t.Errorf("case %s: expected NotRun, got %s", tc.Name(), tc.Status().String())
+		}
+		if tc.Reason() != "suite cancelled" {
+			t.Errorf("case %s: expected reason 'suite cancelled', got %q", tc.Name(), tc.Reason())
+		}
+	}
+}
+
+// A normal (uncancelled) run should execute and pass all cases.
+func TestExecuteTestCasesNormalRunPasses(t *testing.T) {
+	suite := newFakeSuite(context.Background())
+	helper := &fakeHelper{numCases: 2}
+	tm, registrant := newTestManager(t, suite, helper)
+
+	if err := executeTestCases(suite, registrant, tm, false, false); err != nil {
+		t.Fatalf("executeTestCases returned error: %v", err)
+	}
+
+	for _, tc := range tm.TestCases() {
+		if !tc.Status().Passed() {
+			t.Errorf("case %s: expected Passed, got %s", tc.Name(), tc.Status().String())
+		}
+	}
+}
+
+// A failing Setup() hook must surface the output it produced in the returned
+// error, so it is not swallowed in the default (non-watch) run mode.
+func TestSetupErrorSurfacesCollectedOutput(t *testing.T) {
+	suite := newFakeSuite(context.Background())
+	helper := &fakeHelper{
+		numCases: 1,
+		setupFn: func() error {
+			fmt.Println("SETUP-OUTPUT-MARKER")
+			return fmt.Errorf("setup boom")
+		},
+	}
+	tm, registrant := newTestManager(t, suite, helper)
+
+	err := executeTestCases(suite, registrant, tm, false, false)
+	if err == nil {
+		t.Fatal("expected a setup error, got nil")
+	}
+	if _, ok := err.(*setupError); !ok {
+		t.Fatalf("expected *setupError, got %T", err)
+	}
+	if !strings.Contains(err.Error(), "SETUP-OUTPUT-MARKER") {
+		t.Errorf("expected setup error to surface collected output, got:\n%s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "setup boom") {
+		t.Errorf("expected setup error to include the underlying error, got:\n%s", err.Error())
+	}
+}
+
+// With pauseCleanup enabled, executeTestCases waits on suite.Context().Done()
+// before cleanup; when the context is already cancelled it must not block.
+func TestPauseCleanupReturnsWhenContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	suite := newFakeSuite(ctx)
+	// No test cases: isolates the pauseCleanup wait from the cancellation
+	// skip-loop, so we specifically prove the pause wait unblocks.
+	helper := &fakeHelper{numCases: 0}
+	tm, registrant := newTestManager(t, suite, helper)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- executeTestCases(suite, registrant, tm, false, true)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("executeTestCases returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executeTestCases blocked on pauseCleanup despite cancelled context")
+	}
+}

--- a/internal/runner/error.go
+++ b/internal/runner/error.go
@@ -7,8 +7,9 @@ import (
 )
 
 type runnerError struct {
-	err      error
-	metadata core.TestRegistrantMetadata
+	err             error
+	metadata        core.TestRegistrantMetadata
+	collectedOutput []string
 }
 
 func (be *runnerError) Error() string {
@@ -24,11 +25,12 @@ type setupError struct {
 	runnerError
 }
 
-func newSetupError(metadata core.TestRegistrantMetadata, err error) *setupError {
+func newSetupError(metadata core.TestRegistrantMetadata, err error, collectedOutput []string) *setupError {
 	return &setupError{
 		runnerError: runnerError{
-			err:      err,
-			metadata: metadata,
+			err:             err,
+			metadata:        metadata,
+			collectedOutput: collectedOutput,
 		},
 	}
 }
@@ -46,11 +48,12 @@ type cleanupError struct {
 	runnerError
 }
 
-func newCleanupError(metadata core.TestRegistrantMetadata, err error) error {
+func newCleanupError(metadata core.TestRegistrantMetadata, err error, collectedOutput []string) error {
 	return &cleanupError{
 		runnerError: runnerError{
-			err:      err,
-			metadata: metadata,
+			err:             err,
+			metadata:        metadata,
+			collectedOutput: collectedOutput,
 		},
 	}
 }

--- a/internal/runner/error.go
+++ b/internal/runner/error.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/microsoft/storm/pkg/storm/core"
 )
@@ -21,6 +22,19 @@ func (be *runnerError) Error() string {
 	)
 }
 
+// outputSection renders the output collected while the failing hook ran as an
+// indented, labelled block, or an empty string if no output was collected.
+// Setup/Cleanup hooks run outside the test report, so without this their
+// stdout/stderr/logrus output would be hidden in the default (non-watch) run
+// mode; surfacing it in the error makes hook failures diagnosable.
+func (be *runnerError) outputSection() string {
+	if len(be.collectedOutput) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("\n---- collected output ----\n%s\n--------------------------",
+		strings.Join(be.collectedOutput, "\n"))
+}
+
 type setupError struct {
 	runnerError
 }
@@ -37,10 +51,11 @@ func newSetupError(metadata core.TestRegistrantMetadata, err error, collectedOut
 
 func (se *setupError) Error() string {
 	return fmt.Sprintf(
-		"setup error in %s '%s': %v",
+		"setup error in %s '%s': %v%s",
 		se.metadata.RegistrantType().String(),
 		se.metadata.Name(),
 		se.err,
+		se.outputSection(),
 	)
 }
 
@@ -60,9 +75,10 @@ func newCleanupError(metadata core.TestRegistrantMetadata, err error, collectedO
 
 func (se *cleanupError) Error() string {
 	return fmt.Sprintf(
-		"cleanup error in %s '%s': %v",
+		"cleanup error in %s '%s': %v%s",
 		se.metadata.RegistrantType().String(),
 		se.metadata.Name(),
 		se.err,
+		se.outputSection(),
 	)
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -34,6 +34,7 @@ func RegisterAndRunTests(suite core.SuiteContext,
 	},
 	args []string,
 	watch bool,
+	pauseCleanup bool,
 	logDir *string,
 	junitPath *string,
 	artifactDir *string,
@@ -80,7 +81,7 @@ func RegisterAndRunTests(suite core.SuiteContext,
 	}
 
 	// Actually run the thing
-	err = executeTestCases(suite, registrantInstance, testMgr, watch)
+	err = executeTestCases(suite, registrantInstance, testMgr, watch, pauseCleanup)
 	testMgr.StopTimer()
 	if err != nil {
 		switch err.(type) {
@@ -126,6 +127,7 @@ func executeTestCases(suite core.SuiteContext,
 	runnable *runnableInstance,
 	testManager *testmgr.StormTestManager,
 	watch bool,
+	pauseCleanup bool,
 ) error {
 
 	ctx := &runnableContext{
@@ -229,6 +231,11 @@ func executeTestCases(suite core.SuiteContext,
 		if suite.AzureDevops() {
 			devops.SetProgress(0.95 * float64(i+1) / float64(totalTestCases))
 		}
+	}
+
+	if pauseCleanup {
+		suite.Logger().Warn("Waiting for external signal before cleanup...")
+		<-suite.Context().Done()
 	}
 
 	// If we have any cleanup functions, run them in reverse order.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -136,9 +136,22 @@ func executeTestCases(suite core.SuiteContext,
 	// If the runnable implements the SetupCleanup interface, we call
 	// the setup method before running the tests.
 	if r, ok := runnable.TestRegistrant.(core.SetupCleanup); ok {
-		err := runCatchPanic(func() error { return r.Setup(ctx) })
-		if err != nil {
-			return newSetupError(runnable, err)
+		suite.Logger().Info("Running Setup() Hook")
+		var setupErr error
+		captured, captureErr := captureOutput(func() {
+			setupErr = runCatchPanic(func() error { return r.Setup(ctx) })
+		}, func(w io.Writer, s string) {
+			if suite.AzureDevops() || watch {
+				fmt.Fprintf(w, "  ├ %s\n", s)
+			}
+		})
+
+		if captureErr != nil {
+			return fmt.Errorf("failed to capture output for Setup(): %w", captureErr)
+		}
+
+		if setupErr != nil {
+			return newSetupError(runnable, setupErr, captured)
 		}
 	}
 
@@ -213,19 +226,43 @@ func executeTestCases(suite core.SuiteContext,
 
 	// If we have any cleanup functions, run them in reverse order.
 	slices.Reverse(cleanupFuncs)
-	for _, f := range cleanupFuncs {
-		runCatchPanic(func() error {
-			f()
-			return nil
+	for i, f := range cleanupFuncs {
+		suite.Logger().Infof("Running cleanup function (%d/%d)", i+1, len(cleanupFuncs))
+		_, err := captureOutput(func() {
+			runCatchPanic(func() error {
+				f()
+				return nil
+			})
+		}, func(w io.Writer, s string) {
+			if suite.AzureDevops() || watch {
+				fmt.Fprintf(w, "  ├ %s\n", s)
+			}
 		})
+
+		if err != nil {
+			suite.Logger().WithError(err).Error("Failed to capture output for cleanup function")
+		}
 	}
 
 	// If the runnable implements the SetupCleanup interface, we call
 	// the Cleanup method after running the tests.
 	if r, ok := runnable.TestRegistrant.(core.SetupCleanup); ok {
-		err := runCatchPanic(func() error { return r.Cleanup(ctx) })
-		if err != nil {
-			return newCleanupError(runnable, err)
+		suite.Logger().Info("Running Cleanup() Hook")
+		var cleanupErr error
+		captured, captureErr := captureOutput(func() {
+			cleanupErr = runCatchPanic(func() error { return r.Cleanup(ctx) })
+		}, func(w io.Writer, s string) {
+			if suite.AzureDevops() || watch {
+				fmt.Fprintf(w, "  ├ %s\n", s)
+			}
+		})
+
+		if captureErr != nil {
+			return fmt.Errorf("failed to capture output for Cleanup(): %w", captureErr)
+		}
+
+		if cleanupErr != nil {
+			return newCleanupError(runnable, cleanupErr, captured)
 		}
 	}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/microsoft/storm/internal/artifacts"
@@ -242,8 +243,9 @@ func executeTestCases(suite core.SuiteContext,
 	slices.Reverse(cleanupFuncs)
 	for i, f := range cleanupFuncs {
 		suite.Logger().Infof("Running cleanup function (%d/%d)", i+1, len(cleanupFuncs))
-		_, err := captureOutput(func() {
-			runCatchPanic(func() error {
+		var cleanupPanic error
+		captured, err := captureOutput(func() {
+			cleanupPanic = runCatchPanic(func() error {
 				f()
 				return nil
 			})
@@ -255,6 +257,16 @@ func executeTestCases(suite core.SuiteContext,
 
 		if err != nil {
 			suite.Logger().WithError(err).Error("Failed to capture output for cleanup function")
+		}
+
+		// A cleanup function panic is otherwise swallowed by runCatchPanic;
+		// surface both the panic and the output it produced (which is hidden in
+		// the default run mode) so the failure is diagnosable.
+		if cleanupPanic != nil {
+			suite.Logger().WithError(cleanupPanic).Error("Cleanup function panicked")
+			if len(captured) > 0 {
+				suite.Logger().Errorf("Cleanup function output:\n%s", strings.Join(captured, "\n"))
+			}
 		}
 	}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -161,6 +161,13 @@ func executeTestCases(suite core.SuiteContext,
 
 	totalTestCases := len(testManager.TestCases())
 	for i, testCase := range testManager.TestCases() {
+		// If the suite context has been cancelled, we should skip running any
+		// remaining test cases.
+		if suite.Context().Err() != nil {
+			testCase.MarkNotRun("suite cancelled")
+			continue
+		}
+
 		// If bail is true, we are no longer running tests. Mark this test case
 		// as not run and 'continue' to iterate over all remaining test cases to
 		// mark them as not run.

--- a/pkg/storm/suite/suite.go
+++ b/pkg/storm/suite/suite.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"reflect"
 	"runtime"
 	"slices"
+	"syscall"
 
+	"github.com/fatih/color"
 	"github.com/microsoft/storm/internal/cli"
 	"github.com/microsoft/storm/internal/collector"
 	"github.com/microsoft/storm/pkg/storm/core"
@@ -44,6 +47,20 @@ func CreateSuite(name string) StormSuite {
 	logger.Infof("Creating suite '%s'", name)
 
 	ctx, cancel := context.WithCancel(context.Background())
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		select {
+		case <-sigCh:
+			logger.Out.Write([]byte("\n\n" + color.YellowString("==== ⚠️  RECEIVED SHUTDOWN SIGNAL, CANCELLING SUITE. ⚠️  ====") + "\n\n"))
+			cancel()
+		case <-ctx.Done():
+			// Context was cancelled programmatically, not by a signal.
+		}
+		signal.Stop(sigCh)
+	}()
 
 	return StormSuite{
 		name:      name,


### PR DESCRIPTION
# 🔍 Description

- Proper context cancellation from signals.
  Previously, a SIGINT/SIGTERM would immediately terminate the process. Now, these signals are handled and used to cancel the suite-wide context, making all test fail immediately from cancellation and stopping further tests from running.

- Add output capturing for setup and cleanup functions. Previously these would show up as top level logs. Now, output is captured and shown as belonging to a specific function much clearly.

- Add a new `-c, --pause-cleanup` when running scenarios/helpers to aid in local debugging. When set, the suite will halt right after test cases are run and wait until a SIGINT/SIGTERM is received, *before* proceeding to execute cleanup functions. This way, a developer can preserve any local environment after a success or failure for further inspection.
