### PR TITLE
feature: Azure DevOps collapsible group sections for live test output

### DIFF
--- a/internal/devops/root.go
+++ b/internal/devops/root.go
@@ -18,3 +18,12 @@ var realStdOut io.Writer = os.Stdout
 func Stdout() io.Writer {
 	return realStdOut
 }
+
+// SetStdout overrides the writer returned by Stdout and used for all Azure
+// DevOps logging commands, returning a function that restores the previous
+// writer. It is intended for tests that need to capture Azure DevOps output.
+func SetStdout(w io.Writer) (restore func()) {
+	prev := realStdOut
+	realStdOut = w
+	return func() { realStdOut = prev }
+}

--- a/internal/devops/root.go
+++ b/internal/devops/root.go
@@ -7,3 +7,14 @@ import (
 
 // realStdOut is the original os.Stdout before any redirection.
 var realStdOut io.Writer = os.Stdout
+
+// Stdout returns the writer bound to the process's original standard output,
+// captured before any redirection. Azure DevOps parses logging commands from
+// both stdout and stderr on separate threads and orders lines by arrival, so
+// commands and any output that must stay strictly ordered relative to them
+// (e.g. ##[group]/##[endgroup] markers and the lines they bracket) should all
+// be written here, to a single shared stream, to avoid stdout/stderr
+// interleaving races in the agent's rendered log.
+func Stdout() io.Writer {
+	return realStdOut
+}

--- a/internal/runner/live_groups_test.go
+++ b/internal/runner/live_groups_test.go
@@ -1,0 +1,153 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/storm/internal/artifacts"
+	"github.com/microsoft/storm/internal/devops"
+	"github.com/microsoft/storm/internal/testmgr"
+	"github.com/microsoft/storm/pkg/storm/core"
+	"github.com/microsoft/storm/pkg/storm/utils"
+
+	"github.com/sirupsen/logrus"
+)
+
+// fakeSuite is a minimal core.SuiteContext for exercising executeTestCases.
+type fakeSuite struct {
+	log *logrus.Logger
+	ado bool
+}
+
+func (s *fakeSuite) Name() string                  { return "storm-test" }
+func (s *fakeSuite) Logger() *logrus.Logger        { return s.log }
+func (s *fakeSuite) Scenarios() []core.Scenario    { return nil }
+func (s *fakeSuite) Scenario(string) core.Scenario { return nil }
+func (s *fakeSuite) Helpers() []core.Helper        { return nil }
+func (s *fakeSuite) Helper(string) core.Helper     { return nil }
+func (s *fakeSuite) AzureDevops() bool             { return s.ado }
+func (s *fakeSuite) Context() context.Context      { return context.Background() }
+
+// fakeHelper is a minimal core.Helper with a single passing test case that
+// emits a line of output.
+type fakeHelper struct{}
+
+func (h *fakeHelper) Name() string { return "hw" }
+func (h *fakeHelper) Args() any    { return nil }
+func (h *fakeHelper) RegisterTestCases(r core.TestRegistrar) error {
+	r.RegisterTestCase("myPassingTestCase", func(tc core.TestCase) error {
+		fmt.Println("hello from the case")
+		return nil
+	})
+	return nil
+}
+
+// TestExecuteTestCasesAzureDevopsGrouping asserts that under Azure DevOps a
+// test case's live output is bracketed by its "(started)" and status lines
+// OUTSIDE a collapsible ##[group]/##[endgroup] section, all on the shared
+// devops stream and in the correct order.
+func TestExecuteTestCasesAzureDevopsGrouping(t *testing.T) {
+	var buf bytes.Buffer
+	restore := devops.SetStdout(&buf)
+	defer restore()
+
+	logger := logrus.New()
+	logger.SetOutput(&bytes.Buffer{}) // keep suite logger noise out of the test output
+	suite := &fakeSuite{log: logger, ado: true}
+
+	helper := &fakeHelper{}
+	registrant := &runnableInstance{Argumented: helper, TestRegistrant: helper}
+
+	artifactManager, err := artifacts.NewArtifactManager(suite, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create artifact manager: %v", err)
+	}
+
+	testMgr, err := testmgr.NewStormTestManager(suite, registrant, artifactManager)
+	if err != nil {
+		t.Fatalf("failed to create test manager: %v", err)
+	}
+
+	if err := executeTestCases(suite, registrant, testMgr, false); err != nil {
+		t.Fatalf("executeTestCases returned error: %v", err)
+	}
+
+	// Split into ANSI-stripped, trimmed lines.
+	var lines []string
+	for _, l := range strings.Split(buf.String(), "\n") {
+		lines = append(lines, strings.TrimRight(utils.RemoveAllANSI(l), " \r"))
+	}
+
+	// indexOf returns the index of the first line satisfying match, or -1.
+	indexOf := func(match func(string) bool) int {
+		for i, l := range lines {
+			if match(l) {
+				return i
+			}
+		}
+		return -1
+	}
+
+	started := indexOf(func(l string) bool { return l == "myPassingTestCase (started)" })
+	group := indexOf(func(l string) bool { return l == "##[group]myPassingTestCase" })
+	output := indexOf(func(l string) bool {
+		return strings.HasPrefix(l, "  ├") && strings.Contains(l, "hello from the case")
+	})
+	endgroup := indexOf(func(l string) bool { return l == "##[endgroup]" })
+	status := indexOf(func(l string) bool { return l == "myPassingTestCase PASS" })
+
+	for _, tc := range []struct {
+		name string
+		idx  int
+	}{
+		{"(started) line", started},
+		{"##[group] line", group},
+		{"forwarded output line", output},
+		{"##[endgroup] line", endgroup},
+		{"status line", status},
+	} {
+		if tc.idx == -1 {
+			t.Fatalf("expected to find %s in output; got:\n%s", tc.name, buf.String())
+		}
+	}
+
+	if !(started < group && group < output && output < endgroup && endgroup < status) {
+		t.Errorf("lines out of order: started=%d group=%d output=%d endgroup=%d status=%d\noutput:\n%s",
+			started, group, output, endgroup, status, buf.String())
+	}
+}
+
+// TestExecuteTestCasesNonAzureDevopsNoMarkers asserts that outside Azure DevOps
+// no group markers are emitted to the shared devops stream.
+func TestExecuteTestCasesNonAzureDevopsNoMarkers(t *testing.T) {
+	var buf bytes.Buffer
+	restore := devops.SetStdout(&buf)
+	defer restore()
+
+	logger := logrus.New()
+	logger.SetOutput(&bytes.Buffer{})
+	suite := &fakeSuite{log: logger, ado: false}
+
+	helper := &fakeHelper{}
+	registrant := &runnableInstance{Argumented: helper, TestRegistrant: helper}
+
+	artifactManager, err := artifacts.NewArtifactManager(suite, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create artifact manager: %v", err)
+	}
+	testMgr, err := testmgr.NewStormTestManager(suite, registrant, artifactManager)
+	if err != nil {
+		t.Fatalf("failed to create test manager: %v", err)
+	}
+
+	if err := executeTestCases(suite, registrant, testMgr, false); err != nil {
+		t.Fatalf("executeTestCases returned error: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "##[group]") || strings.Contains(buf.String(), "##[endgroup]") {
+		t.Errorf("expected no group markers outside Azure DevOps, got:\n%s", buf.String())
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -165,6 +165,24 @@ func executeTestCases(suite core.SuiteContext,
 		// the test case, but it is better than nothing.
 		var startGoroutines = runtime.NumGoroutine()
 
+		// When running under Azure DevOps, wrap each test case's live-streamed
+		// output in a collapsible group so the raw pipeline log is easy to
+		// navigate. The group header is emitted to the real stdout before the
+		// case's output begins streaming, and the group is closed
+		// unconditionally once the case finishes below, regardless of whether
+		// it passed, failed, was skipped, panicked or called runtime.Goexit().
+		//
+		// This is gated on AzureDevops() only (not the -w watch flag) so that
+		// non-ADO live output stays free of stray group markers. Any
+		// ##[group]/##[endgroup] markers emitted by the product-under-test
+		// within the case output are neutralized by the "  ├ " line prefix
+		// added by the forward function below, so they cannot create nested
+		// groups (which ADO does not support).
+		var liveGroup *devops.Group
+		if suite.AzureDevops() {
+			liveGroup = devops.OpenGroup(testCase.Name())
+		}
+
 		// Call the captureOutput function to run the test case and capture its
 		// output. We also forward the output to the console if we are running
 		// in watch mode or in Azure DevOps.
@@ -175,6 +193,14 @@ func executeTestCases(suite core.SuiteContext,
 				fmt.Fprintf(w, "  ├ %s\n", s)
 			}
 		})
+
+		// Close the live output group for this test case, if one was opened.
+		// captureOutput has already restored the real stdout/stderr by this
+		// point, so the ##[endgroup] marker lands on the real stdout right
+		// after the case's streamed output.
+		if liveGroup != nil {
+			liveGroup.Close()
+		}
 
 		// Calculate the difference in goroutine count.
 		delta := runtime.NumGoroutine() - startGoroutines

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -146,6 +146,27 @@ func executeTestCases(suite core.SuiteContext,
 
 	bail := false
 
+	// When running under Azure DevOps we render each test case as:
+	//
+	//     <name> (started)
+	//     ##[group]<name>
+	//       ├ ...streamed case output...
+	//     ##[endgroup]
+	//     <name> <STATUS>
+	//
+	// so the "(started)" and status lines sit OUTSIDE the collapsible group
+	// and correctly bracket it. The agent parses logging commands from both
+	// stdout and stderr and orders lines by arrival across the two streams, so
+	// mixing streams here would race and misplace the markers/boundary lines
+	// (they would fall inside the wrong group). To make ordering deterministic
+	// we route ALL of a case's live output - the boundary lines, the group
+	// markers, and every streamed line (from both the case's stdout and its
+	// stderr/logrus) - onto the single shared devops.Stdout() stream, in
+	// program order. Outside Azure DevOps behaviour is unchanged: boundary
+	// lines go through the suite logger (stderr) and no group markers are
+	// emitted.
+	ado := suite.AzureDevops()
+
 	totalTestCases := len(testManager.TestCases())
 	for i, testCase := range testManager.TestCases() {
 		// If bail is true, we are no longer running tests. Mark this test case
@@ -156,7 +177,14 @@ func executeTestCases(suite core.SuiteContext,
 			continue
 		}
 
-		suite.Logger().Infof("%s (started)", testCase.Name())
+		// Emit the "(started)" boundary line. Under Azure DevOps it goes to the
+		// shared stream (see above) so it renders immediately before, and
+		// outside, the collapsible group.
+		if ado {
+			fmt.Fprintf(devops.Stdout(), "%s (started)\n", testCase.Name())
+		} else {
+			suite.Logger().Infof("%s (started)", testCase.Name())
+		}
 
 		// Capture the number of goroutines before running the test case.
 		// After the test case has run, we compare the number of goroutines to
@@ -165,21 +193,16 @@ func executeTestCases(suite core.SuiteContext,
 		// the test case, but it is better than nothing.
 		var startGoroutines = runtime.NumGoroutine()
 
-		// When running under Azure DevOps, wrap each test case's live-streamed
-		// output in a collapsible group so the raw pipeline log is easy to
-		// navigate. The group header is emitted to the real stdout before the
-		// case's output begins streaming, and the group is closed
-		// unconditionally once the case finishes below, regardless of whether
-		// it passed, failed, was skipped, panicked or called runtime.Goexit().
-		//
-		// This is gated on AzureDevops() only (not the -w watch flag) so that
-		// non-ADO live output stays free of stray group markers. Any
+		// Open the collapsible group for this case's live output. The group is
+		// closed unconditionally once the case finishes below, regardless of
+		// whether it passed, failed, was skipped, panicked or called
+		// runtime.Goexit() (captureOutput always returns). Any
 		// ##[group]/##[endgroup] markers emitted by the product-under-test
 		// within the case output are neutralized by the "  ├ " line prefix
 		// added by the forward function below, so they cannot create nested
 		// groups (which ADO does not support).
 		var liveGroup *devops.Group
-		if suite.AzureDevops() {
+		if ado {
 			liveGroup = devops.OpenGroup(testCase.Name())
 		}
 
@@ -189,15 +212,24 @@ func executeTestCases(suite core.SuiteContext,
 		captured, err := captureOutput(func() {
 			executeTestCase(testCase)
 		}, func(w io.Writer, s string) {
-			if suite.AzureDevops() || watch {
+			// Under Azure DevOps, force every streamed line onto the single
+			// shared stdout stream (ignoring w, which distinguishes the case's
+			// stdout from its stderr) so nothing interleaves across streams and
+			// lands in the wrong group. captureOutput joins its reader
+			// goroutines before returning, so all of these writes complete
+			// before the ##[endgroup] below. Outside ADO, preserve the original
+			// stream and only forward when watching live.
+			if ado {
+				fmt.Fprintf(devops.Stdout(), "  ├ %s\n", s)
+			} else if watch {
 				fmt.Fprintf(w, "  ├ %s\n", s)
 			}
 		})
 
 		// Close the live output group for this test case, if one was opened.
-		// captureOutput has already restored the real stdout/stderr by this
-		// point, so the ##[endgroup] marker lands on the real stdout right
-		// after the case's streamed output.
+		// captureOutput has already restored the real stdout/stderr and joined
+		// its reader goroutines by this point, so the ##[endgroup] marker lands
+		// on the shared stream right after the case's streamed output.
 		if liveGroup != nil {
 			liveGroup.Close()
 		}
@@ -220,19 +252,32 @@ func executeTestCases(suite core.SuiteContext,
 		// Check if the test case caused a bail condition.
 		bail = testCase.IsBailCondition()
 
-		// Output the test case status.
-		suite.Logger().Infof("%s %s", testCase.Name(), testCase.Status().ColorString())
+		// Output the test case status boundary line. Under Azure DevOps it goes
+		// to the shared stream so it renders immediately after, and outside,
+		// the collapsible group.
+		if ado {
+			fmt.Fprintf(devops.Stdout(), "%s %s\n", testCase.Name(), testCase.Status().ColorString())
+		} else {
+			suite.Logger().Infof("%s %s", testCase.Name(), testCase.Status().ColorString())
+		}
 
-		// Print a warning if we suspect the test case has leaked goroutines.
+		// Print a warning if we suspect the test case has leaked goroutines. In
+		// ADO this is routed to the shared stream too so it stays ordered
+		// relative to the boundary lines above.
 		if delta > 0 {
-			suite.Logger().Warnf("Test case %s has leaked goroutines: ended with %d more goroutine(s) than expected", testCase.Name(), delta)
+			leakMsg := fmt.Sprintf("Test case %s has leaked goroutines: ended with %d more goroutine(s) than expected", testCase.Name(), delta)
+			if ado {
+				fmt.Fprintf(devops.Stdout(), "%s\n", leakMsg)
+			} else {
+				suite.Logger().Warn(leakMsg)
+			}
 		}
 
 		// Update progress in Azure DevOps if needed.
 		// Scale test execution progress to a maximum of 95% to leave some room
 		// for cleanup activities. A division by zero is impossible here since
 		// we would not be in this loop if there were no test cases.
-		if suite.AzureDevops() {
+		if ado {
 			devops.SetProgress(0.95 * float64(i+1) / float64(totalTestCases))
 		}
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -157,14 +157,17 @@ func executeTestCases(suite core.SuiteContext,
 	// so the "(started)" and status lines sit OUTSIDE the collapsible group
 	// and correctly bracket it. The agent parses logging commands from both
 	// stdout and stderr and orders lines by arrival across the two streams, so
-	// mixing streams here would race and misplace the markers/boundary lines
-	// (they would fall inside the wrong group). To make ordering deterministic
+	// splitting the markers/boundary lines across streams would race and
+	// misplace them (they could fall inside the wrong group). To prevent that
 	// we route ALL of a case's live output - the boundary lines, the group
 	// markers, and every streamed line (from both the case's stdout and its
-	// stderr/logrus) - onto the single shared devops.Stdout() stream, in
-	// program order. Outside Azure DevOps behaviour is unchanged: boundary
-	// lines go through the suite logger (stderr) and no group markers are
-	// emitted.
+	// stderr/logrus) - onto the single shared devops.Stdout() stream. This
+	// guarantees the group markers and boundary lines are correctly ordered
+	// relative to the streamed output; it does NOT impose an order between
+	// individual stdout and stderr lines within a case, which remain
+	// interleaved as captureOutput's two reader goroutines observe them.
+	// Outside Azure DevOps behaviour is unchanged: boundary lines go through
+	// the suite logger (stderr) and no group markers are emitted.
 	ado := suite.AzureDevops()
 
 	totalTestCases := len(testManager.TestCases())
@@ -209,18 +212,27 @@ func executeTestCases(suite core.SuiteContext,
 		// Call the captureOutput function to run the test case and capture its
 		// output. We also forward the output to the console if we are running
 		// in watch mode or in Azure DevOps.
+		//
+		// captureOutput invokes the forward function from two goroutines (the
+		// stdout and stderr readers). Under Azure DevOps both are directed at
+		// the same devops.Stdout() writer, so a mutex serializes the writes to
+		// keep each forwarded line atomic and prevent byte-level interleaving.
+		var forwardMu sync.Mutex
 		captured, err := captureOutput(func() {
 			executeTestCase(testCase)
 		}, func(w io.Writer, s string) {
 			// Under Azure DevOps, force every streamed line onto the single
 			// shared stdout stream (ignoring w, which distinguishes the case's
-			// stdout from its stderr) so nothing interleaves across streams and
-			// lands in the wrong group. captureOutput joins its reader
-			// goroutines before returning, so all of these writes complete
-			// before the ##[endgroup] below. Outside ADO, preserve the original
-			// stream and only forward when watching live.
+			// stdout from its stderr) so the group markers and boundary lines
+			// stay correctly ordered relative to the streamed output.
+			// captureOutput joins its reader goroutines before returning, so
+			// all of these writes complete before the ##[endgroup] below.
+			// Outside ADO, preserve the original stream and only forward when
+			// watching live.
 			if ado {
+				forwardMu.Lock()
 				fmt.Fprintf(devops.Stdout(), "  ├ %s\n", s)
+				forwardMu.Unlock()
 			} else if watch {
 				fmt.Fprintf(w, "  ├ %s\n", s)
 			}


### PR DESCRIPTION
## Summary

Adds **Azure DevOps collapsible group sections** to storm's live/streamed test output, and makes the section ordering **deterministic**.

When a suite runs under Azure DevOps (`TF_BUILD` / `--azure-devops`), each test case's live-streamed output is now wrapped in its own collapsible `##[group]<case name>` … `##[endgroup]` section, with the `(started)` and `PASS`/`FAIL`/`SKIP` status lines rendered **outside** the fold so they bracket it:

```
install-vm-deps (started)
##[group]install-vm-deps
  ├ ...streamed case detail...
##[endgroup]
install-vm-deps PASS
```

This turns the previously flat, hard-to-scroll live pipeline log into a per-case navigable one.

## Motivation

Part of the migration of Trident's pytest E2E suite to storm-based Go scenarios (microsoft/trident #724). Long E2E runs produce huge live logs in Azure DevOps; per-case collapsible groups make them readable in real time. **microsoft/trident #724 is currently blocked on an unmerged-branch pseudo-version of storm and is waiting on this PR so a storm release can be cut.**

## What changed

Two commits:

1. **Wrap live test-case output in Azure DevOps collapsible groups** — in `internal/runner/runner.go` (`executeTestCases`), open a `devops.OpenGroup(<case name>)` before the case's output streams and close it after, gated on `AzureDevops()` only. The group is closed unconditionally so `##[endgroup]` still fires on pass/fail/skip, panic, `runtime.Goexit()`, and bail-to-NOTR transitions. Product-under-test group markers in the streamed output are neutralized by the existing `  ├ ` line prefix, so no nested groups are produced.

2. **Deterministic ordering** — the ADO agent parses logging commands from *both* stdout and stderr on separate threads and orders lines by arrival, so emitting markers on stdout while `(started)`/status + logrus detail went to stderr raced and misplaced the boundaries. Fix: under ADO, route **all** of a case's live output — boundary lines, group markers, and every streamed line (from both the case's stdout and its stderr/logrus) — onto a single shared stream (`devops.Stdout()`) in program order. Adds a `devops.Stdout()` accessor exposing the pre-redirection stdout writer.

Files: `internal/runner/runner.go`, `internal/devops/root.go` (+89 / -7).

## Compatibility / release notes

- **No breaking changes.** The only public-surface addition is `internal/devops.Stdout()` — and `internal/…` is not importable by consumers, so there is no exported public API change.
- **Non-Azure-DevOps behavior is unchanged**, including `-w` watch: no group markers are emitted and boundary lines still go through the suite logger (stderr). Verified byte-for-byte against `main`.
- **Behavior note (ADO only):** a test case's stderr/logrus detail is now interleaved onto stdout (by design, to eliminate the cross-stream race). Anything consuming a case's stderr separately under ADO would now find it on stdout.
- Suitable for a minor/pre-release bump from `v0.4.0-alpha1` (additive feature, no breaking changes).

## Verification

Local (Go 1.26): `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -s -l .` (clean), and `staticcheck ./...` all pass. Verified end-to-end with the `helloworld` sample under `TF_BUILD=1` (correct single-stream ordering) and without ADO (unchanged). Confirmed passing in a live Azure DevOps pipeline run of the Trident E2E suite (34/34 scenarios).
